### PR TITLE
docs: add README for AlgoQA HyperExecute sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 This sample shows how to run AlgoQA-generated Cucumber tests with Selenium on the TestMu AI HyperExecute cloud using Java and Maven.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
-- Follow the documentation on [Run Cucumber Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/cucumber-on-hyperexecute-grid/) (Formerly LambdaTest) for the full setup walkthrough.
+- Follow the documentation on [Run Cucumber Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/hyperexecute-algoqa-integration/) (Formerly LambdaTest) for the full setup walkthrough.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 This sample shows how to run AlgoQA-generated Cucumber tests with Selenium on the TestMu AI HyperExecute cloud using Java and Maven.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
-- Follow the documentation on [Run Cucumber Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/hyperexecute-algoqa-integration/) (Formerly LambdaTest) for the full setup walkthrough.
+- Follow the documentation on [Run AlgoQA Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/hyperexecute-algoqa-integration/) (Formerly LambdaTest) for the full setup walkthrough.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 This sample shows how to run AlgoQA-generated Cucumber tests with Selenium on the TestMu AI HyperExecute cloud using Java and Maven.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
-- Follow the documentation on [Run AlgoQA Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/hyperexecute-algoqa-integration/) (Formerly LambdaTest) for the full setup walkthrough.
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,130 @@
+# Run AlgoQA Tests with Cucumber and HyperExecute on TestMu AI (Formerly LambdaTest)
+
+<p align="center">
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://mvnrepository.com/artifact/io.cucumber/cucumber-java"><img src="https://img.shields.io/maven-central/v/io.cucumber/cucumber-java.svg?style=for-the-badge&labelColor=000000" alt="Cucumber Java"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
+</p>
+
+## Getting Started
+
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks.
+
+This sample shows how to run AlgoQA-generated Cucumber tests with Selenium on the TestMu AI HyperExecute cloud using Java and Maven.
+
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the documentation on [Run Cucumber Tests with HyperExecute on TestMu AI](https://www.testmuai.com/support/docs/cucumber-on-hyperexecute-grid/) (Formerly LambdaTest) for the full setup walkthrough.
+
+### Prerequisites
+
+- Java 8 or higher
+- Maven
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
+- HyperExecute CLI downloaded for your OS
+
+### Setup
+
+Clone and install dependencies:
+
+```bash
+git clone https://github.com/LambdaTest/algoQA-HyperExecute-sample
+cd algoQA-HyperExecute-sample
+mvn -Dmaven.repo.local=./.m2 dependency:resolve
+```
+
+Set your credentials as environment variables.
+
+**macOS / Linux:**
+
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
+
+**Windows:**
+
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
+
+Download the HyperExecute CLI for your OS:
+
+- Mac: https://downloads.lambdatest.com/hyperexecute/darwin/hyperexecute
+- Linux: https://downloads.lambdatest.com/hyperexecute/linux/hyperexecute
+- Windows: https://downloads.lambdatest.com/hyperexecute/windows/hyperexecute.exe
+
+### Run tests
+
+Execute your Cucumber tests on HyperExecute using the CLI:
+
+**macOS / Linux:**
+
+```bash
+./hyperexecute --config hyperexecute-agloqa.yaml --user $LT_USERNAME --key $LT_ACCESS_KEY
+```
+
+**Windows:**
+
+```bash
+hyperexecute.exe --config hyperexecute-agloqa.yaml --user %LT_USERNAME% --key %LT_ACCESS_KEY%
+```
+
+View results on your TestMu AI dashboard.
+
+### Local testing with TestMu AI Tunnel
+
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
+
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
+
+Add the following to your capabilities:
+
+```js
+tunnel: true,
+```
+
+## Contributions
+
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your Java version, OS, and Maven version.
+
+## TestMu AI (Formerly LambdaTest) Community
+
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+
+## TestMu AI (Formerly LambdaTest) Certifications
+
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
+
+## Learning Resources by TestMu AI (Formerly LambdaTest)
+
+Learn modern testing through tutorials, guides, videos, and weekly updates:
+
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+
+## LambdaTest is Now TestMu AI
+
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
+
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
+
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
+
+### How LambdaTest Evolved into TestMu AI
+
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
+
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
+
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm.
+
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
+
+## Support
+
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
## Summary
- Added README from scratch (repo had no README)
- Follows standard TestMu AI template structure
- Framework: Java + Cucumber + Selenium + Maven on HyperExecute
- Docs link: https://www.testmuai.com/support/docs/cucumber-on-hyperexecute-grid/

Generated with [Claude Code](https://claude.com/claude-code)